### PR TITLE
add button style

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,16 +1,21 @@
+import React from 'react';
 import { StatusBar } from "expo-status-bar";
 import { StyleSheet, Text, View } from "react-native";
-import { TailwindProvider } from 'tailwind-rn';
-import utilities from './tailwind.json';
+import FlatButton from "./Button";
+// import { TailwindProvider } from 'tailwind-rn';
+// import utilities from './tailwind.json';
 
 export default function App() {
+
+  const pressHandler = ()=> console.log('i am a button and i just got clicked!')
+
   return (
-    <TailwindProvider utilities={utilities}>
+    // <TailwindProvider utilities={utilities}>
       <View style={styles.container}>
-        <Text style={styles.greeting}>it is working</Text>
         <StatusBar style="auto" />
+        <FlatButton text='Exchange Currency!' onPress={pressHandler} />
       </View>
-    </TailwindProvider>
+    // </TailwindProvider>
   );
 }
 

--- a/Button.js
+++ b/Button.js
@@ -1,0 +1,81 @@
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { 
+    Raleway_100Thin,
+    Raleway_100Thin_Italic,
+    Raleway_200ExtraLight,
+    Raleway_200ExtraLight_Italic,
+    Raleway_300Light,
+    Raleway_300Light_Italic,
+    Raleway_400Regular,
+    Raleway_400Regular_Italic,
+    Raleway_500Medium,
+    Raleway_500Medium_Italic,
+    Raleway_600SemiBold,
+    Raleway_600SemiBold_Italic,
+    Raleway_700Bold,
+    Raleway_700Bold_Italic,
+    Raleway_800ExtraBold,
+    Raleway_800ExtraBold_Italic,
+    Raleway_900Black,
+    Raleway_900Black_Italic 
+  } from '@expo-google-fonts/raleway'
+
+import { useFonts } from "expo-font";
+import AppLoading from "expo-app-loading";
+// import { useTailwind } from "tailwind-rn/dist";
+
+const FlatButton = ({ onPress, text }) => {
+	// const tailwind = useTailwind();
+
+    let [fontsLoaded, error] = useFonts({
+        Raleway_100Thin,
+        Raleway_100Thin_Italic,
+        Raleway_200ExtraLight,
+        Raleway_200ExtraLight_Italic,
+        Raleway_300Light,
+        Raleway_300Light_Italic,
+        Raleway_400Regular,
+        Raleway_400Regular_Italic,
+        Raleway_500Medium,
+        Raleway_500Medium_Italic,
+        Raleway_600SemiBold,
+        Raleway_600SemiBold_Italic,
+        Raleway_700Bold,
+        Raleway_700Bold_Italic,
+        Raleway_800ExtraBold,
+        Raleway_800ExtraBold_Italic,
+        Raleway_900Black,
+        Raleway_900Black_Italic 
+    })
+
+    if (!fontsLoaded) {
+        return <AppLoading />
+    }
+	return (
+       <TouchableOpacity onPress={onPress}>
+           <View style={styles.button}>
+               <Text style={styles.buttonText}>{text}</Text>
+           </View>
+       </TouchableOpacity>
+	);
+};
+
+export default FlatButton;
+
+const styles = StyleSheet.create({
+	button: {
+		paddingVertical: 14,
+        paddingHorizontal: 16,
+        borderRadius: 8,
+        backgroundColor: "#1E1D1Eda"
+	},
+	buttonText: {
+        color: "#fff",
+        textTransform: 'uppercase',
+        fontSize: 16,
+        textAlign: "center",
+        fontFamily: 'Raleway_800ExtraBold_Italic',
+        letterSpacing: 2,
+	},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "currencyexchanger",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/raleway": "^0.2.2",
         "@expo/webpack-config": "~0.16.2",
         "expo": "~45.0.0",
+        "expo-app-loading": "~2.0.0",
         "expo-status-bar": "~1.3.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -1760,6 +1762,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@expo-google-fonts/raleway": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/raleway/-/raleway-0.2.2.tgz",
+      "integrity": "sha512-/MUWS14hN9K25PgS7viQwZwasijwL1plIs1gSFu03uyaMCoSMXXrp+Jc1Am51Gj7IomPfVqSOhrbkSfYTeq6cQ=="
+    },
     "node_modules/@expo/bunyan": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@expo/bunyan/-/bunyan-4.0.0.tgz",
@@ -2064,6 +2071,77 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/configure-splash-screen/-/configure-splash-screen-0.6.0.tgz",
+      "integrity": "sha512-4DyPoNXJqx9bN4nEwF3HQreo//ECu7gDe1Xor3dnnzFm9P/VDxAKdbEhA0n+R6fgkNfT2onVHWijqvdpTS3Xew==",
+      "dependencies": {
+        "color-string": "^1.5.3",
+        "commander": "^5.1.0",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.6",
+        "lodash": "^4.17.15",
+        "pngjs": "^5.0.0",
+        "xcode": "^3.0.0",
+        "xml-js": "^1.6.11"
+      },
+      "bin": {
+        "configure-splash-screen": "build/index-cli.js",
+        "expo-splash-screen": "build/index-cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@expo/configure-splash-screen/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@expo/dev-server": {
@@ -9436,6 +9514,14 @@
         "expo-error-recovery": "~3.1.0"
       }
     },
+    "node_modules/expo-app-loading": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-app-loading/-/expo-app-loading-2.0.0.tgz",
+      "integrity": "sha512-Ym0Xteo15642UGDh11nTRa/pmbIVvvEczG7nu0N+n3SKln6nZlLk7pmwI2hcdk1Jgo+2IkC/3n9NmQWvkgkPHA==",
+      "dependencies": {
+        "expo-splash-screen": "~0.15.0"
+      }
+    },
     "node_modules/expo-application": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-4.1.0.tgz",
@@ -9711,6 +9797,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.15.1.tgz",
+      "integrity": "sha512-Yvz6p/ig+cQp9c1PLSm1YshpNJXRp/xtxajfwPq2kampf61zA+xnoMk+J6YcNeXeIlqHysj3ND2tMhEEQjM/ow==",
+      "dependencies": {
+        "@expo/configure-splash-screen": "^0.6.0",
+        "@expo/prebuild-config": "~4.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {
@@ -22694,6 +22792,17 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -24017,6 +24126,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@expo-google-fonts/raleway": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/raleway/-/raleway-0.2.2.tgz",
+      "integrity": "sha512-/MUWS14hN9K25PgS7viQwZwasijwL1plIs1gSFu03uyaMCoSMXXrp+Jc1Am51Gj7IomPfVqSOhrbkSfYTeq6cQ=="
+    },
     "@expo/bunyan": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@expo/bunyan/-/bunyan-4.0.0.tgz",
@@ -24265,6 +24379,58 @@
       "version": "45.0.0",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-45.0.0.tgz",
       "integrity": "sha512-/QGhhLWyaGautgEyU50UJr5YqKJix5t77ePTwreOVAhmZH+ff3nrrtYTTnccx+qF08ZNQmfAyYMCD3rQfzpiJA=="
+    },
+    "@expo/configure-splash-screen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/configure-splash-screen/-/configure-splash-screen-0.6.0.tgz",
+      "integrity": "sha512-4DyPoNXJqx9bN4nEwF3HQreo//ECu7gDe1Xor3dnnzFm9P/VDxAKdbEhA0n+R6fgkNfT2onVHWijqvdpTS3Xew==",
+      "requires": {
+        "color-string": "^1.5.3",
+        "commander": "^5.1.0",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.6",
+        "lodash": "^4.17.15",
+        "pngjs": "^5.0.0",
+        "xcode": "^3.0.0",
+        "xml-js": "^1.6.11"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "pngjs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
     },
     "@expo/dev-server": {
       "version": "0.1.110",
@@ -30059,6 +30225,14 @@
         "uuid": "^3.4.0"
       }
     },
+    "expo-app-loading": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-app-loading/-/expo-app-loading-2.0.0.tgz",
+      "integrity": "sha512-Ym0Xteo15642UGDh11nTRa/pmbIVvvEczG7nu0N+n3SKln6nZlLk7pmwI2hcdk1Jgo+2IkC/3n9NmQWvkgkPHA==",
+      "requires": {
+        "expo-splash-screen": "~0.15.0"
+      }
+    },
     "expo-application": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-4.1.0.tgz",
@@ -30267,6 +30441,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "expo-splash-screen": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.15.1.tgz",
+      "integrity": "sha512-Yvz6p/ig+cQp9c1PLSm1YshpNJXRp/xtxajfwPq2kampf61zA+xnoMk+J6YcNeXeIlqHysj3ND2tMhEEQjM/ow==",
+      "requires": {
+        "@expo/configure-splash-screen": "^0.6.0",
+        "@expo/prebuild-config": "~4.0.0"
       }
     },
     "expo-status-bar": {
@@ -40326,6 +40509,14 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
           "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "xml2js": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:tailwind": "concurrently \"tailwindcss --input input.css --output tailwind.css --no-autoprefixer --watch\" \"tailwind-rn --watch\""
   },
   "dependencies": {
+    "@expo-google-fonts/raleway": "^0.2.2",
     "@expo/webpack-config": "~0.16.2",
     "expo": "~45.0.0",
     "expo-status-bar": "~1.3.0",
@@ -20,7 +21,8 @@
     "react-native": "0.68.2",
     "react-native-web": "0.17.7",
     "tailwind-rn": "^4.2.0",
-    "webpack-dev-server": "~3.11.0"
+    "webpack-dev-server": "~3.11.0",
+    "expo-app-loading": "~2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Managed to add button and style.
- If you use imported Button from 'react-native', you can't custom its style so I found different way to do it. 
- Style property names are different from normal CSS.
- Importing google font needed something unusual. I had to install expo-google-font(? you can check from package.json)

![image](https://user-images.githubusercontent.com/59310859/168122117-e6519d39-b194-4df8-a992-5d5cff7c7b19.png)
